### PR TITLE
Fix compilation with GHC 7.0 and 7.2

### DIFF
--- a/HaskellNet.cabal
+++ b/HaskellNet.cabal
@@ -47,7 +47,6 @@ Library
 
   Build-Depends:
     base >= 4 && < 5,
-    haskell98,
     network,
     mtl,
     bytestring,

--- a/src/Text/Packrat/Parse.hs
+++ b/src/Text/Packrat/Parse.hs
@@ -5,8 +5,8 @@ module Text.Packrat.Parse where
 
 import Prelude hiding (exp, rem)
 
-import Char
-import List
+import Data.Char
+import Data.List
 
 import Text.Packrat.Pos
 


### PR DESCRIPTION
The problem is with importing Prelude and importing Data.Char and Data.List.

Tested on GHC 7.2, 7.0 and 6.12.
