### PR TITLE
Adding show constraint to show6 in Network/HaskellNet/IMAP.hs for compatibility with GHC 7.4.1

### DIFF
--- a/src/Network/HaskellNet/IMAP.hs
+++ b/src/Network/HaskellNet/IMAP.hs
@@ -136,7 +136,7 @@ sendCommand' c cmdstr = do
   resp <- getResponse (stream c)
   return (resp, num)
 
-show6 :: (Ord a, Num a) => a -> String
+show6 :: (Ord a, Num a, Show a) => a -> String
 show6 n | n > 100000 = show n
         | n > 10000  = '0' : show n
         | n > 1000   = "00" ++ show n


### PR DESCRIPTION
I've just upgraded to GHC 7.4.1 and could not compile HaskellNet until I added a Show constraint to the show6 function in Network/HaskellNet/IMAP.hs.

This is due to the removal of the Show instance for Num. There shouldn't be any backwards compatibility issues as the same constraint was previously implied.
