### PR TITLE
Fix store command to enable Office365 support

### DIFF
--- a/src/Network/HaskellNet/IMAP.hs
+++ b/src/Network/HaskellNet/IMAP.hs
@@ -398,7 +398,7 @@ fetchCommand conn command proc =
 storeFull :: IMAPConnection -> String -> FlagsQuery -> Bool
           -> IO [(UID, [Flag])]
 storeFull conn uidstr query isSilent =
-    fetchCommand conn ("UID STORE " ++ uidstr ++ flgs query) procStore
+    fetchCommand conn ("UID STORE " ++ uidstr ++ " " ++ flgs query) procStore
     where fstrs fs = "(" ++ (concat $ intersperse " " $ map show fs) ++ ")"
           toFStr s fstrs' =
               s ++ (if isSilent then ".SILENT" else "") ++ " " ++ fstrs'


### PR DESCRIPTION
Adding a space between UID and flags in STORE command. This should have been there all the time, but while some IMAP servers (notably Gmail) accepts that it is missing, others (notably Office365) requires it. This pull request also enables the close of issue #14
