### PR TITLE
remove closeSMTP at end of sendMimeMail

### DIFF
--- a/src/Network/HaskellNet/SMTP.hs
+++ b/src/Network/HaskellNet/SMTP.hs
@@ -243,7 +243,6 @@ sendMimeMail to from subject plainBody htmlBody attachments con = do
             plainBody htmlBody attachments
   renderedMail <- renderMail' myMail
   sendMail from [to] (lazyToStrict renderedMail) con
-  closeSMTP con
   where
     address = Address Nothing . T.pack
 


### PR DESCRIPTION
sendMail and sendMimeMail should have the same behaviour towards the connection given to the function. In addition, Office365 causes the closeSMTP of sendMimeMail to raise an exception of already closed. Thus, removed.
