### PR TITLE
Fix parser error when passing parameters to FETCH

### DIFF
--- a/src/Network/HaskellNet/IMAP/Parsers.hs
+++ b/src/Network/HaskellNet/IMAP/Parsers.hs
@@ -321,7 +321,11 @@ pFetchLine =
        char ')'
        crlfP
        return $ Right $ (read num, pairs)
-    where pPair = do key <- anyChar `manyTill` space
+    where pPair = do key <- (do k  <- anyChar `manyTill` char '['
+                                ps <- anyChar `manyTill` char ']'
+                                space
+                                return (k++"["++ps++"]"))
+                        <|> anyChar `manyTill` space
                      value <- (do char '('
                                   v <- pParen `sepBy` space
                                   char ')'


### PR DESCRIPTION
As reported in this StackOverflow post:

http://stackoverflow.com/questions/26183675/error-when-fetching-subject-from-email-using-haskellnets-imap

Passing parameters to the query string you use in `fetchByString` would
break the parser which was splitting input on spaces regardless of
whether it was inside square brackets so a response like

```
"* 2 FETCH (UID 2 BODY[HEADER.FIELDS (SUBJECT)] {43}\r"
```

would be split into:

```
UID                  2
BODY[HEADER.FIELDS   (SUBJECT)]
{43}                 #ERROR (No value)
```

This commit simply includes anything in square brackets as part of the
key, so that the above string would be split as follows:

```
UID                               2
BODY[HEADER.FIELDS (SUBJECT)]     {43}
```
