### PR TITLE
Move to base64 package.

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -36,12 +36,6 @@ jobs:
             allow-failure: false
           - ghc: 8.2.2
             allow-failure: false
-          - ghc: 8.0.2
-            allow-failure: false
-          - ghc: 7.10.3
-            allow-failure: false
-          - ghc: 7.8.4
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
@@ -131,8 +125,8 @@ jobs:
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_HaskellNet}" >> cabal.project
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package HaskellNet" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          echo "package HaskellNet" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(HaskellNet)$/; }' >> cabal.project.local

--- a/HaskellNet.cabal
+++ b/HaskellNet.cabal
@@ -71,7 +71,7 @@ Library
     pretty,
     array,
     cryptohash-md5,
-    base64-string,
+    base64,
     old-time,
     mime-mail >= 0.4.7 && < 0.6,
     text

--- a/HaskellNet.cabal
+++ b/HaskellNet.cabal
@@ -17,10 +17,7 @@ Homepage:       https://github.com/qnikst/HaskellNet
 Cabal-version:  >=1.10
 Build-type:     Simple
 Tested-with:
-  GHC ==7.8.4
-   || ==7.10.3
-   || ==8.0.2
-   || ==8.2.2
+  GHC ==8.2.2
    || ==8.4.4
    || ==8.6.5
    || ==8.8.4

--- a/src/Network/HaskellNet/Auth.hs
+++ b/src/Network/HaskellNet/Auth.hs
@@ -2,13 +2,14 @@ module Network.HaskellNet.Auth
 where
 
 import Crypto.Hash.MD5
-import qualified Codec.Binary.Base64.String as B64 (encode, decode)
+import Data.Text.Encoding.Base64 as B64
 
 import Data.Word
 import Data.List
 import Data.Bits
 import Data.Array
 import qualified Data.ByteString as B
+import qualified Data.Text as T
 
 type UserName = String
 type Password = String
@@ -26,14 +27,10 @@ instance Show AuthType where
               showMain CRAM_MD5 = "CRAM-MD5"
 
 b64Encode :: String -> String
-b64Encode = map (toEnum.fromEnum)
-          -- Hotfix for https://github.com/jtdaugherty/HaskellNet/issues/61
-          . delete '\n'
-          . B64.encode
-          . map (toEnum.fromEnum)
+b64Encode = T.unpack . B64.encodeBase64 . T.pack
 
 b64Decode :: String -> String
-b64Decode = map (toEnum.fromEnum) . B64.decode . map (toEnum.fromEnum)
+b64Decode = T.unpack . B64.decodeBase64Lenient . T.pack
 
 showOctet :: [Word8] -> String
 showOctet = concatMap hexChars


### PR DESCRIPTION
We move to the base64 package as more stable and correct.
At this point of time we do not switch types in order not
to break API, but in the future we would be able to use
more appropriate types (Text or Short bytestring variant).

This commit fixes #61.