### PR TITLE
[issue-33] Simplify mail sending API.

### DIFF
--- a/HaskellNet.cabal
+++ b/HaskellNet.cabal
@@ -14,7 +14,7 @@ License:        BSD3
 License-file:   LICENSE
 Category:       Network
 Homepage:       https://github.com/qnikst/HaskellNet
-Cabal-version:  >=1.10
+Cabal-version:  1.22
 Build-type:     Simple
 Tested-with:
   GHC ==8.4.4
@@ -59,6 +59,8 @@ Library
     Network.Compat
     Text.Packrat.Pos
     Text.Packrat.Parse
+  Reexported-modules:
+    Network.Mail.Mime
 
   Build-Depends:
     base >= 4.3 && < 4.15,

--- a/example/smtp.hs
+++ b/example/smtp.hs
@@ -22,37 +22,44 @@ htmlBody     = "<html><head></head><body><h1>Hello <i>world!</i></h1></body></ht
 attachments  = [] -- example [("application/octet-stream", "/path/to/file1.tar.gz), ("application/pdf", "/path/to/file2.pdf")]
 
 -- | Send plain text mail
-example1 = doSMTP server $ \conn ->
-    sendPlainTextMail to from subject plainBody conn
+example1 = doSMTP server $ \conn -> do
+    let mail = simpleMail' to from subject plainBody
+    sendMail mail conn
 
 -- | With custom port number
-example2 = doSMTPPort server port $ \conn ->
-    sendPlainTextMail to from subject plainBody conn
+example2 = doSMTPPort server port $ \conn -> do
+    let mail = simpleMail' to from subject plainBody
+    sendMail mail conn
 
 -- | Manually open and close the connection
 example3 = do
     conn <- connectSMTP server
-    sendPlainTextMail to from subject plainBody conn
+    let mail = simpleMail' to from subject plainBody
+    sendMail mail conn
     closeSMTP conn
 
 -- | Send mime mail
-example4 = doSMTP server $ \conn ->
-    sendMimeMail to from subject plainBody htmlBody [] conn
+example4 = doSMTP server $ \conn -> do
+    mail <-  simpleMail to from subject plainBody htmlBody []
+    sendMail mail conn
 
 -- | With file attachments (modify the `attachments` binding)
-example5 = doSMTP server $ \conn ->
-    sendMimeMail to from subject plainBody htmlBody attachments conn
+example5 = doSMTP server $ \conn -> do
+    mail <-  simpleMail to from subject plainBody htmlBody attachments
+    sendMail mail conn
 
 -- | With ByteString attachments
 bsContent = B.pack [43,43,43,43]
-example5_2 = doSMTP server $ \conn ->
-    sendMimeMail' to from subject plainBody htmlBody [("application/zip", "filename.zip", bsContent)] conn
+example5_2 = doSMTP server $ \conn -> do
+    let mail = simpleMailInMemory to from subject plainBody htmlBody [("application/zip", "filename.zip", bsContent)]
+    sendMail mail conn
 
 -- | With authentication
 example6 = doSMTP server $ \conn -> do
     authSuccess <- authenticate authType username password conn
     if authSuccess
-        then sendMimeMail to from subject plainBody htmlBody [] conn
+        then do mail <- simpleMail to from subject plainBody htmlBody []
+                sendMail mail conn
         else putStrLn "Authentication failed."
 
 -- | Custom
@@ -62,11 +69,10 @@ example7 = do
                        [(Address Nothing "to@test.org")]
                        [(Address Nothing "cc1@test.org"), (Address Nothing "cc2@test.org")]
                        []
-                       [("Subject", T.pack subject)]
+                       [("Subject", subject)]
                        [[htmlPart htmlBody, plainPart plainBody]]
     newMail' <- addAttachments attachments newMail
-    renderedMail <- renderMail' newMail'
-    sendMail from [to] (S.concat . B.toChunks $ renderedMail) conn
+    sendMail newMail' conn
     closeSMTP conn
 
 main = example1


### PR DESCRIPTION
Instead of having mulitple methods with puzzling names for sending
emails, we use only one instead. We provided documentation how
to use mime-mail package to mimic old functions. The change is safe
as all the functions were just a wrappers over the mime-mail functions,
but those wrappers does not provide all the functionality of the package.

Current approach should be much simpler and error prone.