### PR TITLE
Support for some Gmail IMAP extensions

### DIFF
--- a/src/Network/HaskellNet/IMAP.hs
+++ b/src/Network/HaskellNet/IMAP.hs
@@ -70,6 +70,7 @@ data SearchQuery = ALLs
                  | SUBJECTs String
                  | TEXTs String
                  | TOs String
+                 | XGMRAW String
                  | UIDs [UID]
 
 
@@ -99,6 +100,7 @@ instance Show SearchQuery where
               showQuery (SUBJECTs s)    = "SUBJECT " ++ s
               showQuery (TEXTs s)       = "TEXT " ++ s
               showQuery (TOs addr)      = "TO " ++ addr
+              showQuery (XGMRAW s)      = "X-GM-RAW " ++ s
               showQuery (UIDs uids)     = concat $ intersperse "," $
                                           map show uids
               showFlag Seen        = "SEEN"

--- a/src/Network/HaskellNet/IMAP/Types.hs
+++ b/src/Network/HaskellNet/IMAP/Types.hs
@@ -1,5 +1,6 @@
 module Network.HaskellNet.IMAP.Types
     ( MailboxName
+    , GmailLabel
     , UID
     , Charset
     , MailboxInfo(..)
@@ -14,30 +15,24 @@ module Network.HaskellNet.IMAP.Types
     )
 where
 
-import Data.Word
-    ( Word64
-    )
-import Text.Packrat.Parse
-    ( Result
-    , Derivs(..)
-    )
-import Text.Packrat.Pos
-    ( Pos
-    )
+import           Data.Word          (Word64)
+import           Text.Packrat.Parse (Derivs (..), Result)
+import           Text.Packrat.Pos   (Pos)
 
 type MailboxName = String
 type UID = Word64
 type Charset = String
+type GmailLabel = String
 
-data MailboxInfo = MboxInfo { _mailbox :: MailboxName
-                            , _exists :: Integer
-                            , _recent :: Integer
-                            , _flags :: [Flag]
+data MailboxInfo = MboxInfo { _mailbox        :: MailboxName
+                            , _exists         :: Integer
+                            , _recent         :: Integer
+                            , _flags          :: [Flag]
                             , _permanentFlags :: [Flag]
-                            , _isWritable :: Bool
+                            , _isWritable     :: Bool
                             , _isFlagWritable :: Bool
-                            , _uidNext :: UID
-                            , _uidValidity :: UID
+                            , _uidNext        :: UID
+                            , _uidValidity    :: UID
                             }
                  deriving (Show, Eq)
 
@@ -104,10 +99,10 @@ data MailboxStatus = MESSAGES     -- ^ the number of messages in the mailbox
 
 
 data RespDerivs =
-    RespDerivs { dvFlags  :: Result RespDerivs [Flag]
-               , advTag   :: Result RespDerivs String
-               , advChar  :: Result RespDerivs Char
-               , advPos   :: Pos
+    RespDerivs { dvFlags :: Result RespDerivs [Flag]
+               , advTag  :: Result RespDerivs String
+               , advChar :: Result RespDerivs Char
+               , advPos  :: Pos
                }
 
 instance Derivs RespDerivs where


### PR DESCRIPTION
This pull request contains fixes motivated by my project which uses this library to work with Gmail over IMAP:

1. Support for `X-GM-LABLES` [extension](https://developers.google.com/gmail/imap/imap-extensions) on STORE
2. Support for `X-GM-RAW` search query (Gmail extension)
2. Function `appendFull` is now exported to be able to specify message date
3. Fixed bug in `appendFull` implementation which prevented specifying message dates

Disclaimer: I did not implement full support for Gmail IMAP extensions. I only implemented a subset of it needed to append and label messages.

