### PR TITLE
`base64-0.5` is gonna be a breaking change

### DIFF
--- a/HaskellNet.cabal
+++ b/HaskellNet.cabal
@@ -75,7 +75,7 @@ Library
     pretty,
     array,
     cryptohash-md5,
-    base64,
+    base64 < 0.5,
     old-time,
     mime-mail >= 0.4.7 && < 0.6,
     text


### PR DESCRIPTION
see https://github.com/emilypi/base64/commit/f322d492aa5a4293933ca131a893fa8aca215eb9#diff-147ea6ceb80cd72bed5931a174cb77e791621b7f79386c47843f4195e95f6c85 for one of the commits

will have a compat PR up soon