### PR TITLE
Support base64 >= 0.5

### DIFF
--- a/HaskellNet.cabal
+++ b/HaskellNet.cabal
@@ -68,7 +68,7 @@ Library
     Network.Mail.Mime
 
   Build-Depends:
-    base >= 4.3 && < 4.17,
+    base >= 4.3 && < 4.18,
     network >= 2.6.3.1 && < 3.2,
     mtl,
     bytestring >=0.10.2,

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,10 @@
+packages:
+    .
+
+-- https://github.com/emilypi/base64/pull/46
+source-repository-package
+    type: git
+    location: https://github.com/ysangkok/base64
+    tag: 5e3f36d07680f3369fb6b6ab5d3a0fb025a3a265
+
+

--- a/cabal.project
+++ b/cabal.project
@@ -1,10 +1,2 @@
 packages:
     .
-
--- https://github.com/emilypi/base64/pull/46
-source-repository-package
-    type: git
-    location: https://github.com/ysangkok/base64
-    tag: 5e3f36d07680f3369fb6b6ab5d3a0fb025a3a265
-
-

--- a/src/Network/HaskellNet/Auth.hs
+++ b/src/Network/HaskellNet/Auth.hs
@@ -1,8 +1,15 @@
+{-# language CPP #-}
+
 module Network.HaskellNet.Auth
 where
 
 import Crypto.Hash.MD5
 import Data.Text.Encoding.Base64 as B64
+
+#if MIN_VERSION_base64(0,5,0)
+import Data.Base64.Types as B64
+
+#endif
 
 import Data.Word
 import Data.List
@@ -28,10 +35,24 @@ instance Show AuthType where
               showMain CRAM_MD5 = "CRAM-MD5"
 
 b64Encode :: String -> String
-b64Encode = T.unpack . B64.encodeBase64 . T.pack
+b64Encode = T.unpack . encode . T.pack
+    where encode =
+#if MIN_VERSION_base64(0,5,0)
+              B64.extractBase64 . B64.encodeBase64
+#else
+              B64.encodeBase64
+#endif
+
+
 
 b64Decode :: String -> String
-b64Decode = T.unpack . B64.decodeBase64Lenient . T.pack
+b64Decode = T.unpack . decode . T.pack
+    where decode =
+#if MIN_VERSION_base64(0,5,0)
+              B64.decodeBase64Lenient . B64.assertBase64
+#else
+              B64.decodeBase64Lenient
+#endif
 
 showOctet :: [Word8] -> String
 showOctet = concatMap hexChars

--- a/src/Network/HaskellNet/Auth.hs
+++ b/src/Network/HaskellNet/Auth.hs
@@ -8,7 +8,6 @@ import Data.Text.Encoding.Base64 as B64
 
 #if MIN_VERSION_base64(0,5,0)
 import Data.Base64.Types as B64
-
 #endif
 
 import Data.Word


### PR DESCRIPTION
This PR adds support for `base64` impending new version. May not be necessary or useful at the moment.