### PR TITLE
fix: use std lookup where needed

### DIFF
--- a/src/Network/HaskellNet/IMAP.hs
+++ b/src/Network/HaskellNet/IMAP.hs
@@ -382,7 +382,7 @@ fetchHeader conn uid =
 fetchSize :: IMAPConnection -> UID -> IO Int
 fetchSize conn uid =
     do lst <- fetchByString conn uid "RFC822.SIZE"
-       return $ maybe 0 read $ lookup' "RFC822.SIZE" lst
+       return $ maybe 0 read $ lookup "RFC822.SIZE" lst
 
 fetchHeaderFields :: IMAPConnection
                   -> UID -> [String] -> IO ByteString
@@ -401,7 +401,7 @@ fetchHeaderFieldsNot conn uid hs =
 fetchFlags :: IMAPConnection -> UID -> IO [Flag]
 fetchFlags conn uid =
     do lst <- fetchByString conn uid "FLAGS"
-       return $ getFlags $ lookup' "FLAGS" lst
+       return $ getFlags $ lookup "FLAGS" lst
     where getFlags Nothing  = []
           getFlags (Just s) = eval' dvFlags "" s
 


### PR DESCRIPTION
Follow-up of #93. Both `fetchSize` and `fetchFlags` work on association lists where the keys are the plain command string, so the standard lookup works fine. This leaves the `lookup'` for cases where the returned keys are prefixed with `UID <number>`, namely range fetches and search.

Tested locally:

- [x] `fetch`
- [x] `fetchHeader`
- [x] `fetchSize`
- [x] `fetchHeaderFields`
- [x] `fetchHeaderFieldsNot`
- [x] `fetchFlags`
- [x] `fetchR`
- [x] `fetchByStringR`