### PR TITLE
Fixed typo

### DIFF
--- a/src/Network/HaskellNet/IMAP/Parsers.hs
+++ b/src/Network/HaskellNet/IMAP/Parsers.hs
@@ -237,7 +237,7 @@ pListLine list =
        return $ Right (attrs, sep, mbox)
     where parseAttr =
               do char '\\'
-                 choice [ string "Noinferior" >> return Noinferiors
+                 choice [ string "Noinferiors" >> return Noinferiors
                         , string "Noselect" >> return Noselect
                         , string "Marked" >> return Marked
                         , string "Unmarked" >> return Unmarked


### PR DESCRIPTION
Fixes a typo in the `pListLine` parser. IMAP uses `Noinferiors` instead of `Noinferior`. That causes lines in the output of `IMAP.list` that contain `Noinferiors` to not show up.

E.g. an output like this:

```
* LIST (\\Noinferiors \\Sent) \"/\" \"Sent\"\r\n
```

Cannot be parsed with the current parser.