### PR TITLE
Added support for IMAP move operation

### DIFF
--- a/src/Network/HaskellNet/IMAP.hs
+++ b/src/Network/HaskellNet/IMAP.hs
@@ -11,7 +11,7 @@ module Network.HaskellNet.IMAP
     , list, lsub, status, append, appendFull
       -- ** selected state commands
     , check, close, expunge
-    , search, store, copy
+    , search, store, copy, move
     , idle
       -- * fetch commands
     , fetch, fetchHeader, fetchSize, fetchHeaderFields, fetchHeaderFieldsNot
@@ -456,6 +456,9 @@ copyFull conn uidStr mbox =
 
 copy :: IMAPConnection -> UID -> MailboxName -> IO ()
 copy conn uid mbox     = copyFull conn (show uid) mbox
+
+move :: IMAPConnection -> UID -> MailboxName -> IO ()
+move conn uid mboxname = sendCommand conn ("UID MOVE " ++ show uid ++ " " ++ mboxname) pNone
 
 ----------------------------------------------------------------------
 -- auxialiary functions


### PR DESCRIPTION
This implement the IMAP move operation that is supported by some mail servers.

Usage:

```haskell
-- Move email uid to mailbox "MyMailbox"
IMAP.move con uid "MyMailbox"
```

(While it might not be easy to test, I have used this function on my local fork in prod for a year)