### PR TITLE
bump network to allow version 3.2.*

### DIFF
--- a/HaskellNet.cabal
+++ b/HaskellNet.cabal
@@ -68,7 +68,7 @@ Library
 
   Build-Depends:
     base >= 4.3 && < 4.19,
-    network >= 2.6.3.1 && < 3.2,
+    network >= 2.6.3.1 && < 3.3,
     mtl >= 2.2.2 && < 2.4,
     bytestring >=0.10.2 && < 0.12,
     pretty >= 1.1.3 && < 1.2,


### PR DESCRIPTION
# Motivation

On hackage there is a network 3.2.7 published and the module structure did not change enough to make this package not compile. This bumps the limits to `< 3.3` 