### PR TITLE
Fix IMAP keyword flag handling

### DIFF
--- a/src/Network/HaskellNet/IMAP/Parsers.hs
+++ b/src/Network/HaskellNet/IMAP/Parsers.hs
@@ -189,7 +189,7 @@ pFlag = do char '\\'
                   , string "Draft"    >> return Draft
                   , string "Recent"   >> return Recent
                   , char '*'          >> return (Keyword "*")
-                  , many1 atomChar    >>= return . Keyword ]
+                  , many1 atomChar    >>= return . Keyword . ('\\':) ]
     <|> (many1 atomChar >>= return . Keyword)
 
 pParenFlags :: RespDerivs -> Result RespDerivs [Flag]

--- a/src/Network/HaskellNet/IMAP/Types.hs
+++ b/src/Network/HaskellNet/IMAP/Types.hs
@@ -61,7 +61,8 @@ instance Show Flag where
               showFlag Deleted     = "\\Deleted"
               showFlag Draft       = "\\Draft"
               showFlag Recent      = "\\Recent"
-              showFlag (Keyword s) = "\\" ++ s
+              showFlag (Keyword "*") = "\\*"
+              showFlag (Keyword s)   = s
 
 data Attribute = Noinferiors
                | Noselect

--- a/test/IMAPParsersTest.hs
+++ b/test/IMAPParsersTest.hs
@@ -184,6 +184,19 @@ fetchTest =
                               \a005 OK +FLAGS completed\r\n"
     ]
 
+flagTest =
+    [ "keyword show omits backslash" ~:
+          "Custom" ~=? show (Keyword "Custom")
+    , "permanent wildcard show keeps backslash" ~:
+          "\\*" ~=? show (Keyword "*")
+    , "keyword parser keeps bare keyword" ~:
+          [Keyword "Custom"] ~=? eval' dvFlags "" "(Custom)"
+    , "keyword parser keeps permanent wildcard" ~:
+          [Keyword "*"] ~=? eval' dvFlags "" "(\\*)"
+    , "keyword parser preserves unknown system flag" ~:
+          [Keyword "\\Custom"] ~=? eval' dvFlags "" "(\\Custom)"
+    ]
+
 
 testData = [ "base" ~: baseTest
            , "capability" ~: capabilityTest
@@ -194,6 +207,7 @@ testData = [ "base" ~: baseTest
            , "expunge" ~: expungeTest
            , "search" ~: searchTest
            , "fetch" ~: fetchTest
+           , "flags" ~: flagTest
            ]
 
 


### PR DESCRIPTION
## Summary

Fix keyword flag handling according to RFC 3501 section 2.3.2:

- `show (Keyword "Custom")` now renders `Custom` instead of `\Custom`
- bare keyword flags still parse as keywords
- unknown backslash-prefixed system flags are preserved distinctly instead of being collapsed into bare keywords

Fixes #1.
Fixes #2.

## Checks

- `nix shell nixpkgs#cabal-install nixpkgs#ghc --command cabal test imap-parsers --test-show-details=direct`
- `nix shell nixpkgs#cabal-install nixpkgs#ghc --command cabal build all`
- `nix shell nixpkgs#cabal-install nixpkgs#ghc --command cabal check` (existing `CHANGELOG` placement warning only)
- `git diff --check`