### PR TITLE
[codex] Fix IMAP fetch when BODY precedes UID

### DIFF
--- a/src/Network/HaskellNet/IMAP.hs
+++ b/src/Network/HaskellNet/IMAP.hs
@@ -545,10 +545,31 @@ bsPutCrLf h s = bsPut h s >> bsPut h crlf >> bsFlush h
 
 lookup' :: String -> [(String, b)] -> Maybe b
 lookup' _ [] = Nothing
-lookup' q ((k,v):xs) | q == query k  = return v
+lookup' q ((k,v):xs) | matchesFetchKey q k = return v
                      | otherwise        = lookup' q xs
-    where
-        query = unwords . drop 2 . words
+
+matchesFetchKey :: String -> String -> Bool
+matchesFetchKey expected actual =
+    normalizeFetchKey expected == normalizeFetchKey actual ||
+    normalizeFetchKey expected == normalizeFetchKey (stripUIDPrefix actual)
+
+normalizeFetchKey :: String -> String
+normalizeFetchKey = stripOrigin . stripPeek . map toUpper
+  where
+    stripPeek key =
+        case stripPrefix "BODY.PEEK[" key of
+          Just rest -> "BODY[" ++ rest
+          Nothing -> key
+    stripOrigin key =
+        case break (== '<') key of
+          (bodySection, '<':_) | "BODY[" `isPrefixOf` bodySection -> bodySection
+          _ -> key
+
+stripUIDPrefix :: String -> String
+stripUIDPrefix key =
+    case words key of
+      "UID" : _ : rest -> unwords rest
+      _ -> key
 
 -- TODO: This is just a first trial solution for this stack overflow question:
 --       http://stackoverflow.com/questions/26183675/error-when-fetching-subject-from-email-using-haskellnets-imap

--- a/test/IMAPParsersTest.hs
+++ b/test/IMAPParsersTest.hs
@@ -11,8 +11,6 @@ import Network.HaskellNet.IMAP.Parsers
 import Network.HaskellNet.IMAP.Types
 import System.Exit
 
-import System.Exit
-
 import Test.HUnit
 
 data ReadStep = ReadLine ByteString | ReadBytes ByteString
@@ -57,6 +55,9 @@ scriptedConnection steps = do
 line :: String -> ReadStep
 line = ReadLine . BS.pack
 
+bytes :: String -> ReadStep
+bytes = ReadBytes . BS.pack
+
 okLine :: String -> ReadStep
 okLine = line . ("000000 OK " ++)
 
@@ -70,6 +71,7 @@ assertCommand name expected steps action =
         _ <- action conn
         actual <- written
         expected @=? actual
+
 
 baseTest =
     [(OK Nothing "LOGIN Completed", MboxUpdate Nothing Nothing, ())
@@ -332,6 +334,19 @@ flagTest =
     ]
 
 
+imapFetchTest =
+    [ "fetch works when BODY precedes UID" ~: TestCase $ do
+          (conn, _) <- scriptedConnection
+              [ line "* 12 FETCH (BODY[] {5}"
+              , bytes "hello"
+              , line " UID 999)"
+              , okLine "FETCH completed"
+              ]
+          fetched <- IMAP.fetch conn 999
+          BS.pack "hello" @=? fetched
+    ]
+
+
 testData = [ "base" ~: baseTest
            , "capability" ~: capabilityTest
            , "noop" ~: noopTest
@@ -343,6 +358,7 @@ testData = [ "base" ~: baseTest
            , "fetch" ~: fetchTest
            , "imap commands" ~: imapCommandTest
            , "flags" ~: flagTest
+           , "imap fetch api" ~: imapFetchTest
            ]
 
 


### PR DESCRIPTION
## Summary

Fix `IMAP.fetch` returning an empty `ByteString` when a `UID FETCH` response contains `BODY[]` before the server-supplied `UID` item.

The previous `lookup'` implementation assumed parsed fetch keys needed their first two words dropped, which only worked for the older parser artifact where keys looked like `UID <n> BODY[]`. When the response key is simply `BODY[]`, the lookup misses and `fetch` falls back to `BS.empty`.

This change normalizes fetch keys before comparison, preserving compatibility with the `UID <n>` prefix form while also matching direct `BODY[]` keys, `BODY.PEEK[]`, and origin suffixes such as `BODY[]<0>`.

## Tests

- `nix shell nixpkgs#haskell.compiler.ghc948 nixpkgs#cabal-install --command cabal test imap-parsers --test-show-details=direct`