### PR TITLE
Add GHC 9.14.1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         - "9.8.4"
         - "9.10.2"
         - "9.12.2"
+        - "9.14.1"
         exclude:
         # These don't work on GitHub CI anymore because they need llvm@13, which became
         # disabled on 12/31/2024

--- a/HaskellNet.cabal
+++ b/HaskellNet.cabal
@@ -24,6 +24,7 @@ Tested-with:
    || ==9.8.4
    || ==9.10.2
    || ==9.12.2
+   || ==9.14.1
 
 Extra-Source-Files:
   CHANGELOG
@@ -67,7 +68,7 @@ Library
     Network.Mail.Mime
 
   Build-Depends:
-    base >= 4.3 && < 4.22,
+    base >= 4.3 && < 4.23,
     network >= 2.6.3.1 && < 3.3,
     mtl >= 2.2.2 && < 2.4,
     bytestring >=0.10.2 && < 0.13,
@@ -94,6 +95,6 @@ Test-suite imap-parsers
   Main-is: IMAPParsersTest.hs
   default-language: Haskell2010
   Build-Depends:
-    base >= 4.3 && < 4.22,
+    base >= 4.3 && < 4.23,
     HaskellNet,
     HUnit >= 1.6 && < 1.7


### PR DESCRIPTION
## Summary

- Add GHC 9.14.1 to the Cabal CI matrix.
- Update `Tested-with` to include GHC 9.14.1.
- Relax the `base` upper bound to `< 4.23` for GHC 9.14/base-4.22.
- Leave the Stack matrix unchanged because current Stackage Nightly has not moved to GHC 9.14 yet.

## Validation

- `git diff --check --cached`
- `cabal check` (existing `CHANGELOG` doc-placement warning only)
- `cabal build all --enable-tests --enable-benchmarks`
- `cabal test all --test-show-details=direct`