### PR TITLE
Regression test for Office365/Exchange trailing FETCH fields (#15)

### DIFF
--- a/test/IMAPParsersTest.hs
+++ b/test/IMAPParsersTest.hs
@@ -298,7 +298,7 @@ imapCommandTest =
           commandBytes "000000 STATUS \"foo bar\" (MESSAGES)" @=? actual
     , "append preserves raw crlf message bytes" ~: TestCase $ do
           let mailData = BS.pack "Subject: x\r\n\r\nBody\r\n"
-              expectedCommand = "000000 APPEND INBOX {" ++ show (BS.length mailData) ++ "}"
+              expectedCommand = "000000 APPEND \"INBOX\" {" ++ show (BS.length mailData) ++ "}"
           (conn, written) <- scriptedConnection
               [ line "+ Ready for literal"
               , okLine "APPEND completed"
@@ -364,6 +364,19 @@ imapFetchTest =
               , okLine "FETCH completed"
               ]
           fetched <- IMAP.fetch conn 42
+          body @=? fetched
+    , "fetch tolerates trailing UID/FLAGS after body literal (Office365/Exchange, #15)" ~: TestCase $ do
+          -- Office365 and Exchange append "UID nn FLAGS (\\Seen)" after the
+          -- BODY[] literal, before the closing ')'. The old Parsec parser
+          -- rejected this with "expected space or )".
+          let body = BS.pack "Content-Transfer-Encoding: quoted-printable\r\n\r\n"
+          (conn, _) <- scriptedConnection
+              [ line ("* 12 FETCH (BODY[] {" ++ show (BS.length body) ++ "}")
+              , ReadBytes body
+              , line " UID 12 FLAGS (\\Seen))"
+              , okLine "FETCH completed"
+              ]
+          fetched <- IMAP.fetch conn 12
           body @=? fetched
     , "fetchPeek reads body response without setting Seen" ~: TestCase $ do
           let body = BS.pack "peeked"


### PR DESCRIPTION
## What

Adds a regression test for [#15](https://github.com/qnikst/HaskellNet/issues/15) — Office365 and Exchange append `UID nn FLAGS (\Seen)` after the `BODY[]` literal, before the closing `)`. The old Parsec FETCH parser rejected this with `expected space or )`.

The streaming FETCH parser introduced in #111 already tolerates trailing fields (it loops consuming key/value pairs until `)`), so `IMAP.fetch` now returns the body correctly. This test locks the behaviour in by feeding the exact wire shape from the issue through `IMAP.fetch` via the mock stream:

```
* 12 FETCH (BODY[] {nnn}
<body bytes>
 UID 12 FLAGS (\Seen))
000004 OK FETCH completed.
```

## Also

Fixes the stale `append preserves raw crlf message bytes` expectation. Since the mailbox-quoting change (0e242d9), `APPEND` correctly quotes the mailbox name (`"INBOX"`), but that test still expected the unquoted form and was failing on `master`. Expectation updated to match.

## Verification

`cabal test imap-parsers` — 48/48 pass (was 47 with 1 pre-existing failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #15
