### PR TITLE
Add exact UID-set fetch API

### DIFF
--- a/src/Network/HaskellNet/IMAP.hs
+++ b/src/Network/HaskellNet/IMAP.hs
@@ -16,7 +16,7 @@ module Network.HaskellNet.IMAP
       -- * fetch commands
     , fetch, fetchHeader, fetchSize, fetchHeaderFields, fetchHeaderFieldsNot
     , fetchFlags, fetchR, fetchByString, fetchByStringR
-    , fetchByByteString, fetchByByteStringR
+    , fetchByByteString, fetchByByteStringR, fetchByByteStringSet
     , fetchPeek, fetchRPeek
       -- * other types
     , Flag(..), Attribute(..), MailboxStatus(..)
@@ -463,6 +463,19 @@ fetchByByteStringR :: IMAPConnection -> (UID, UID) -> String
                    -> IO [(UID, [(String, ByteString)])]
 fetchByByteStringR conn (s, e) command =
     fetchCommandBS conn ("UID FETCH "++show s++":"++show e++" "++command) proc
+    where proc (n, ps) =
+              (maybe (toEnum (fromIntegral n)) (read . BS.unpack) (lookup' "UID" ps), ps)
+
+-- | Fetch arbitrary data items for an exact set of UIDs.
+--
+-- Unlike 'fetchByByteStringR', this does not fetch messages whose UIDs happen
+-- to lie between sparse search results.
+fetchByByteStringSet :: IMAPConnection -> [UID] -> String
+                     -> IO [(UID, [(String, ByteString)])]
+fetchByByteStringSet _ [] _ = return []
+fetchByByteStringSet conn uids command =
+    fetchCommandBS conn
+        ("UID FETCH "++intercalate "," (map show uids)++" "++command) proc
     where proc (n, ps) =
               (maybe (toEnum (fromIntegral n)) (read . BS.unpack) (lookup' "UID" ps), ps)
 

--- a/test/IMAPParsersTest.hs
+++ b/test/IMAPParsersTest.hs
@@ -427,6 +427,26 @@ imapFetchTest =
               ]
           fetched <- IMAP.fetchR conn (1, 2)
           [(101, firstBody), (102, secondBody)] @=? fetched
+    , "fetchByByteStringSet fetches an exact sparse UID set" ~: TestCase $ do
+          let firstStructure = BS.pack "(\"TEXT\" \"PLAIN\")"
+              secondStructure = BS.pack "(\"APPLICATION\" \"PDF\")"
+          (conn, written) <- scriptedConnection
+              [ line "* 1 FETCH (BODYSTRUCTURE (\"TEXT\" \"PLAIN\") UID 101)"
+              , line "* 2 FETCH (BODYSTRUCTURE (\"APPLICATION\" \"PDF\") UID 999)"
+              , okLine "FETCH completed"
+              ]
+          fetched <- IMAP.fetchByByteStringSet conn [101, 205, 999] "BODYSTRUCTURE"
+          [ (101, [("BODYSTRUCTURE", firstStructure), ("UID", BS.pack "101")])
+            , (999, [("BODYSTRUCTURE", secondStructure), ("UID", BS.pack "999")])
+            ] @=? fetched
+          actual <- written
+          commandBytes "000000 UID FETCH 101,205,999 BODYSTRUCTURE" @=? actual
+    , "fetchByByteStringSet skips the command for an empty UID set" ~: TestCase $ do
+          (conn, written) <- scriptedConnection []
+          fetched <- IMAP.fetchByByteStringSet conn [] "BODYSTRUCTURE"
+          [] @=? fetched
+          actual <- written
+          B.empty @=? actual
     , "fetchByString keeps scalar and literal values compatible" ~: TestCase $ do
           let headers = BS.pack "hello"
           (conn, _) <- scriptedConnection


### PR DESCRIPTION
## Summary

- add `fetchByByteStringSet` for fetching arbitrary data items from an exact list of UIDs
- encode sparse UIDs as an IMAP sequence-set such as `101,205,999`, rather than widening them to a range
- return immediately for an empty UID list without sending an invalid `UID FETCH` command
- preserve the existing raw `ByteString` values and response-UID mapping used by `fetchByByteStringR`

## Why

IMAP searches commonly return sparse UIDs. The existing `fetchByByteStringR` API accepts only a contiguous range, so using the first and last search result can fetch many unrelated messages between them. Calling the single-UID API in a loop avoids over-fetching but adds one network round trip per message.

This helper allows callers to batch metadata reads such as `BODYSTRUCTURE` for exactly the search results they need.

## Validation

- Nix `doCheck` build with GHC 9.10.3
- `imap-parsers`: 50 cases, 0 errors, 0 failures
- Haddock generation
- regression coverage for sparse and empty UID sets
